### PR TITLE
fix(main): remove stdout of the snippet

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ func main() {
 
 	http.HandleFunc("/ajs-proxy.min.js", func(w http.ResponseWriter, r *http.Request) {
 		snippet, err := ioutil.ReadFile("static/ajs-proxy.min.js")
-		os.Stdout.Write(snippet)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return


### PR DESCRIPTION
This single line made the logs > 36G for this service alone in 6 days. There's no need to output this to the standard output, is completely safe to remove.