### PR TITLE
use docker multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,31 @@
 # This is the dockerfile we use to run the project locally as well as
 # compile the code for a slim production image
-FROM golang:1.8.3-alpine3.6
+FROM golang:1.10-alpine3.7 as builder
 
-ENV CGO_ENABLED=0\
-    GOOS=linux
+ENV CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
 WORKDIR /go/src/github.com/InVisionApp/segment-proxy
 
 # Add rest of source code
 COPY . ./
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w' -o segment-proxy .
-RUN cp segment-proxy /segment-proxy
+RUN CGO_ENABLED=$CGO_ENABLED \
+  GOOS=$GOOS \
+  GOARCH=$GOARCH \
+  go build \
+    -a -tags netgo -ldflags '-w -extldflags "-static"' \
+    -o segment-proxy .
+
+FROM alpine:3.7
+
+RUN apk add --update --no-cache ca-certificates
+
+COPY --from=builder /go/src/github.com/InVisionApp/segment-proxy/segment-proxy /segment-proxy
+COPY --from=builder /go/src/github.com/InVisionApp/segment-proxy/static /static
 
 ENV PORT 80
 EXPOSE 80
+WORKDIR /
 ENTRYPOINT ["/segment-proxy"]


### PR DESCRIPTION
Thanks for the updates to the segment proxy! 

This PR enables a much slimmer dockerfile image (8.9MB instead of 270MB) via using docker's multistage build system.

I've also taken the opportunity to update golang and alpine to current stable versions which doesn't seem to break anything in my use of the image.

We use helm to deploy this image to kubernetes, if it would be helpful for you or others, I'd be happy to send the chart across as well.